### PR TITLE
Enables importing Ink-ripple module

### DIFF
--- a/lib/Tab.js
+++ b/lib/Tab.js
@@ -23,18 +23,21 @@ var Tab = _react2['default'].createClass({
   getStyle: function getStyle() {
     var style = this.props.style;
 
-    return {
+       return {
       container: {
         position: 'relative',
         height: 48,
-        padding: '0 12px',
+        padding: '0 0px',
         cursor: 'pointer'
       },
       text: {
         container: {
           position: 'relative',
-          top: '50%',
-          transform: 'translateY(-60%)',
+     height:'100%',
+     width:'100%',
+     display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
           textAlign: 'center',
           textTransform: 'uppercase',
           color: style.color || '#FFFFFF',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "Tabs"
   ],
   "homepage": "https://github.com/oliverfencott/material-tabs#readme",
+  "devDependencies":{
+      "react": "^0.13.3"
+  },
   "dependencies": {
-    "react": "^0.13.3"
+
   }
 }

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -13,18 +13,21 @@ const Tab = React.createClass({
   getStyle: function() {
     const {style} = this.props;
 
-    return {
+      return {
       container: {
         position: 'relative',
         height: 48,
-        padding: '0 12px',
+        padding: '0 0px',
         cursor: 'pointer'
       },
       text: {
         container: {
           position: 'relative',
-          top: '50%',
-          transform: 'translateY(-60%)',
+     height:"100%",
+     width:"100%",
+     display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
           textAlign: 'center',
           textTransform: 'uppercase',
           color: style.color || '#FFFFFF',

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -23,11 +23,11 @@ const Tab = React.createClass({
       text: {
         container: {
           position: 'relative',
-     height:"100%",
-     width:"100%",
-     display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
+     height:'100%',
+     width:'100%',
+     display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
           textAlign: 'center',
           textTransform: 'uppercase',
           color: style.color || '#FFFFFF',


### PR DESCRIPTION
I had an issue with setting `<Ink />` Component as a child of `<Tab />` component because ripple effect did not stretch to full width and height. The children were not expanding to full width and height. So I changed some CSS (remove padding) and put some flex properties in order to center it. 

The `<Ink />` component is from react-ink npm package https://github.com/vigetlabs/react-ink

The changes do not affect anything and all works fine without Ink component.
