### PR TITLE
Replace misleading CSS property in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ By default, the following styles are applied:
 ```TabGroup``` accepts the following style prop:
 
 ```js
-style={{ indicator: { color: '#FF5722' } }}
+style={{ indicator: { backgroundColor: '#FF5722' } }}
 ```
 
 


### PR DESCRIPTION
I spent some time figuring out why my indicator wouldn't change the color 😆, so I thought maybe the README could suggest the right CSS property to change the indicator color.